### PR TITLE
Fix regex in README

### DIFF
--- a/README.org
+++ b/README.org
@@ -1,6 +1,6 @@
 #+TITLE: README
 * Implementation
-  Let's implement =c[ad]{2,4}r= (i.e. { =car=, =cdr=, =cadr=, ...,
+  Let's implement =c[ad]{1,4}r= (i.e. { =car=, =cdr=, =cadr=, ...,
   =cddddr= }) in Clojure; according to the following composition table:
 
   #+BEGIN_QUOTE


### PR DESCRIPTION
Since this library provides `car` and `cdr` in addition to the weird and wonderful family of sublist manipulators, the regex in the README is inaccurate as `c[ad]{2,4}r` doesn't match `car` or `cdr`. Clearly this is the most crippling bug in the universe and renders this library completely unusable, so I trust you'll treat this pull request with all the immediacy and gravitas it deserves.
